### PR TITLE
chore: enforce LF line endings (fix Windows Prettier noise)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
-* text=auto
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
 .husky/pre-commit text eol=lf
 .husky/commit-msg text eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,7 @@
   "singleQuote": true,
   "trailingComma": "none",
   "semi": false,
+  "endOfLine": "lf",
   "importOrder": [
     "",
     "^react$",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  "files.eol": "\n",
   "sonarlint.analyzerProperties": {
     "sonar.exclusions": "**/.env,**/.env.*"
   }


### PR DESCRIPTION
## Summary

- **`.prettierrc`:** `"endOfLine": "lf"`
- **`.vscode/settings.json`:** `"files.eol": "\n"` for format-on-save
- **`.gitattributes`:** `* text=auto eol=lf` (+ binary exceptions)

Stops phantom hundreds-of-files `git status` noise and flaky `yarn format:check` on Windows without changing application code.

## Test plan

- [x] `yarn validate`