### PR TITLE
chore: LF line endings for stable Prettier on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
-* text=auto
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
 .husky/pre-commit text eol=lf
 .husky/commit-msg text eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,7 @@
   "singleQuote": true,
   "trailingComma": "none",
   "semi": false,
+  "endOfLine": "lf",
   "importOrder": [
     "",
     "^react$",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  "files.eol": "\n",
   "sonarlint.analyzerProperties": {
     "sonar.exclusions": "**/.env,**/.env.*"
   }


### PR DESCRIPTION
## Summary

- Enforce LF via `.prettierrc`, `.gitattributes`, and VS Code `files.eol`
- Fixes phantom mass `git status` / flaky `yarn format:check` on Windows

## Test plan

- [x] `yarn validate` (#41)